### PR TITLE
split_paragraphs.py - Decode content only if it is bytes

### DIFF
--- a/back_translate/split_paragraphs.py
+++ b/back_translate/split_paragraphs.py
@@ -103,7 +103,8 @@ def main(_):
   tf.logging.info("splitting sentence")
   for i in range(len(contents)):
     contents[i] = contents[i].strip()
-    contents[i] = contents[i].decode("utf-8")
+    if isinstance(contents[i], bytes):
+      contents[i] = contents[i].decode("utf-8")
     sent_list = sent_tokenizer(contents[i])
     has_long = False
     if i % 100 == 0:


### PR DESCRIPTION
When running back_translate/run.sh with Python 3 interpreter translation fails because decode is called on 'str' types. Avoid decoding if the content is already decoded